### PR TITLE
[Hotfix] Fix Storybook GitHub Pages deployment - resolve Rollup platform dependency issue

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -34,12 +34,10 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Install platform-specific Rollup dependencies
         run: |
-          # Install the specific Rollup platform dependency that's missing
-          npm install @rollup/rollup-linux-x64-gnu --no-save --force
+          # Use npm install instead of npm ci to resolve platform-specific dependencies
+          # This allows npm to install the correct platform binaries for the Ubuntu runner
+          npm install
           
       - name: Build Storybook
         run: npm run build-storybook


### PR DESCRIPTION
## Summary
- Fix Storybook GitHub Pages deployment failing with Rollup platform dependency error
- Use `npm install` instead of `npm ci` for better platform dependency resolution
- Ensure both Fly.io and Storybook deployments work correctly

## Problem
The Storybook deployment to GitHub Pages was failing with `Cannot find module @rollup/rollup-linux-x64-gnu` error after recent dependency cleanup. This prevented the pregnancy-safe design system documentation from being deployed.

**Root Cause**: The recent package-lock.json regeneration during Docker fixes introduced platform-specific dependency resolution issues that affect GitHub Actions Ubuntu runners.

## Solution
**Final Fix**: Use `npm install` instead of `npm ci` in Storybook workflow:
- Allows npm to resolve platform-specific dependencies dynamically
- Works around package-lock.json platform compatibility issues 
- Addresses the regenerated dependency tree from recent Docker fixes

**Previous attempts**:
- ❌ Adding explicit `@rollup/rollup-linux-x64-gnu` installation (too narrow)
- ✅ Switching to `npm install` for flexible dependency resolution

## Test Plan
- [x] Local Storybook build works perfectly (`npm run build-storybook` succeeds)
- [ ] Manual workflow triggers (experiencing log access issues)
- [ ] Automatic workflow on merge to main
- [ ] Verify Storybook site deploys to GitHub Pages  
- [ ] Confirm Fly.io deployment still works
- [ ] Check that both deployment URLs are accessible

## Critical for Project
This fix is essential for documenting pregnancy-safe components for Pauline Roussel's Quebec perinatal platform.

🤖 Generated with [Claude Code](https://claude.ai/code)