### PR TITLE
[Hotfix] Comprehensive fix for Storybook deployment - remove package-lock.json and node_modules

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -33,10 +33,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
 
-      - name: Install dependencies
+      - name: Install dependencies with clean slate
         run: |
-          # Use npm install instead of npm ci to resolve platform-specific dependencies
-          # This allows npm to install the correct platform binaries for the Ubuntu runner
+          # Follow npm error recommendation: remove package-lock.json and node_modules before npm install
+          # This fixes the optional dependencies bug affecting @rollup/rollup-linux-x64-gnu
+          rm -rf package-lock.json node_modules
           npm install
           
       - name: Build Storybook


### PR DESCRIPTION
## Summary
Follow the exact npm error recommendation to fix Storybook GitHub Pages deployment by removing package-lock.json and node_modules before npm install.

## Problem
Previous attempts to fix the `Cannot find module @rollup/rollup-linux-x64-gnu` error were unsuccessful because we didn't follow the specific npm recommendation. The error message explicitly states:

> "npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory."

## Solution  
**Comprehensive Fix**: Remove both package-lock.json and node_modules before npm install
- This addresses the npm CLI bug affecting optional platform dependencies
- Allows fresh dependency resolution for the Ubuntu runner platform
- Follows the exact recommendation from the Rollup error message

## Previous Attempts
- ❌ Adding explicit `@rollup/rollup-linux-x64-gnu` installation (too narrow)
- ❌ Switching to `npm install` from `npm ci` (still used cached/corrupted lock)
- ✅ **This fix**: Complete clean slate dependency installation

## Test Plan
- [x] Local Storybook build works perfectly  
- [ ] Test comprehensive fix on main branch automatic trigger
- [ ] Verify Storybook site deploys to GitHub Pages
- [ ] Confirm Fly.io deployment still works
- [ ] Check both deployment URLs are accessible

## Critical for Project
This fix is essential for documenting pregnancy-safe components for Pauline Roussel's Quebec perinatal platform.

Reference: https://github.com/npm/cli/issues/4828

🤖 Generated with [Claude Code](https://claude.ai/code)