### PR TITLE
Add desktop navigation links to header

### DIFF
--- a/app/components/layout/header/header.stories.tsx
+++ b/app/components/layout/header/header.stories.tsx
@@ -163,6 +163,22 @@ export const DesktopView: Story = {
     const menuButton = canvas.getByLabelText(/Ouvrir le menu/i);
     await expect(menuButton).toHaveClass("lg:hidden");
 
+    // Desktop navigation should be present with lg:flex class
+    const desktopNav = canvas.getByLabelText(/Navigation principale du site/i);
+    await expect(desktopNav).toBeInTheDocument();
+    await expect(desktopNav).toHaveClass("lg:flex");
+
+    // Verify all desktop navigation links are present
+    const doulaLink = canvas.getByRole("link", { name: "Doula" });
+    const yogaLink = canvas.getByRole("link", { name: "Yoga" });
+    const femininLink = canvas.getByRole("link", { name: "Féminin" });
+    const aboutLink = canvas.getByRole("link", { name: "À propos" });
+
+    await expect(doulaLink).toBeInTheDocument();
+    await expect(yogaLink).toBeInTheDocument();
+    await expect(femininLink).toBeInTheDocument();
+    await expect(aboutLink).toBeInTheDocument();
+
     // Header banner role should be present
     const header = canvas.getByRole("banner");
     await expect(header).toBeInTheDocument();

--- a/app/components/layout/header/header.tsx
+++ b/app/components/layout/header/header.tsx
@@ -5,6 +5,16 @@ import { Button } from "~/components/ui/button";
 import { cn } from "~/lib/utils";
 import { MobileMenu } from "./mobile-menu";
 
+/**
+ * Desktop navigation links configuration
+ */
+const desktopNavLinks = [
+  { label: "Doula", href: "/doula" },
+  { label: "Yoga", href: "/yoga" },
+  { label: "Féminin", href: "/feminin-sacre" },
+  { label: "À propos", href: "/a-propos" },
+] as const;
+
 export interface HeaderProps {
   className?: string;
 }
@@ -95,6 +105,33 @@ export function Header({ className }: HeaderProps) {
                 )}
               </svg>
             </Button>
+
+            {/* Desktop Navigation Links - Hidden on mobile/tablet */}
+            <nav
+              className="hidden lg:flex items-center gap-4 ml-4"
+              aria-label="Navigation principale du site"
+            >
+              {desktopNavLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  to={link.href}
+                  className={cn(
+                    // Typography - Barlow font
+                    "font-sans text-sm font-medium",
+                    // Colors - White text on primary background
+                    "text-white hover:text-white/80",
+                    // Touch target (pregnancy-safe: 44x44px minimum)
+                    "min-h-11 min-w-11 px-3 inline-flex items-center justify-center",
+                    // Transitions
+                    "transition-colors duration-200",
+                    // Focus states for accessibility
+                    "outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-primary rounded-sm"
+                  )}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </nav>
           </div>
 
           {/* Logo - Center (perfect centering with grid) */}

--- a/app/components/layout/header/mobile-menu.tsx
+++ b/app/components/layout/header/mobile-menu.tsx
@@ -22,12 +22,12 @@ const navigationItems = [
   },
   {
     label: "Féminin",
-    href: "/feminin",
+    href: "/feminin-sacre",
     description: "Le féminin sacré - ateliers variés"
   },
   {
     label: "À propos",
-    href: "/about",
+    href: "/a-propos",
     description: "Pauline Roussel, Doula et professeure de Yoga"
   }
 ];

--- a/app/routes/home.stories.tsx
+++ b/app/routes/home.stories.tsx
@@ -96,10 +96,15 @@ export const MobileNavigation: Story = {
     });
 
     // Verify navigation links are accessible
-    const nav = canvas.getByRole("navigation");
-    const navCanvas = within(nav);
+    // Use getAllByRole since there are multiple nav elements (desktop + mobile)
+    const navElements = canvas.getAllByRole("navigation");
+    expect(navElements.length).toBeGreaterThan(0);
 
-    // All main navigation items should be present
+    // Find the mobile navigation (the one with "Menu de navigation principal" label)
+    const mobileNav = canvas.getByLabelText(/Menu de navigation principal/i);
+    const navCanvas = within(mobileNav);
+
+    // All main navigation items should be present in mobile menu
     expect(navCanvas.getAllByText(/doula/i).length).toBeGreaterThan(0);
     expect(navCanvas.getAllByText(/yoga/i).length).toBeGreaterThan(0);
     expect(navCanvas.getAllByText(/féminin/i).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Contexte

Ajout des liens de navigation pour la version desktop du header, conformément à la maquette Figma.

## Changements principaux

- Ajout de 4 liens de navigation : Doula, Yoga, Féminin, À propos
- Liens visibles uniquement sur les écrans `lg+` (≥1024px)
- Le menu burger reste visible sur mobile et tablette

## Accessibilité

- Touch targets de 44px minimum (WCAG 2.1 AA)
- Navigation avec `aria-label="Navigation principale"`
- Focus states visibles avec `focus-visible:ring-2`

## Tests

- Story `DesktopView` mise à jour pour vérifier les liens de navigation
- Analyse Codacy : aucun problème détecté