### PR TITLE
Fix text wrapping on desktop nav links

### DIFF
--- a/app/components/layout/header/header.tsx
+++ b/app/components/layout/header/header.tsx
@@ -117,7 +117,7 @@ export function Header({ className }: HeaderProps) {
                   to={link.href}
                   className={cn(
                     // Typography - Barlow font
-                    "font-sans text-sm font-medium",
+                    "font-sans text-sm font-medium whitespace-nowrap",
                     // Colors - White text on primary background
                     "text-white hover:text-white/80",
                     // Touch target (pregnancy-safe: 44x44px minimum)


### PR DESCRIPTION
## Context
Fix for text wrapping issue on desktop navigation at 1024px breakpoint where "À propos" was displaying on 2 lines.

## Main changes
- Add `whitespace-nowrap` to desktop navigation links

## Accessibility impact
None - touch targets remain at 44px minimum.

## Performance impact
None - single CSS class addition.

Related to #130