### PR TITLE
Limit header container to max-w-7xl for ultra-wide screens

### DIFF
--- a/app/components/layout/header/header.tsx
+++ b/app/components/layout/header/header.tsx
@@ -56,7 +56,7 @@ export function Header({ className }: HeaderProps) {
       )}
       role="banner"
     >
-      <Container size="full" className="h-full">
+      <Container size="xl" className="h-full">
         <div className="grid grid-cols-3 items-center h-full">
           {/* Mobile Menu Trigger - Left side on mobile */}
           <div className="flex items-center justify-start">


### PR DESCRIPTION
## Context
On ultra-wide screens (1920px+), the header content was stretching edge-to-edge, which looks awkward. The background should still extend full width, but the content (logo, navigation, buttons) should be constrained.

## Main changes
- Change `Container` size from `full` to `xl` (max-w-7xl = 1280px)
- Content is now centered with `mx-auto` on large screens
- Background (`bg-primary`) still extends full width

## Visual impact
```
Before (full width content):
┌─────────────────────────────────────────────────────────────┐
│[Burger][Links]           [Logo]                   [Contact] │
└─────────────────────────────────────────────────────────────┘

After (constrained content):
┌─────────────────────────────────────────────────────────────┐
│░░░░[Burger][Links]       [Logo]             [Contact]░░░░░░░│
└─────────────────────────────────────────────────────────────┘
     ↑ max-w-7xl (1280px), centered ↑
```

## Accessibility impact
None - touch targets and focus states unchanged.

## Performance impact
None.

Related to #132