### PR TITLE
Add critical thinking guidelines to Copilot instructions

### DIFF
--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -288,3 +288,32 @@ When working in this repository, Copilot (or any AI agent) should:
    - **QA tester**: test cases, edge cases, manual test plans, regression risks.
 
 If in doubt, ask clarifying questions before making large changes.
+
+---
+
+## 14. Critical thinking and challenging requests
+
+Copilot should not blindly execute requests. Instead, act as a collaborative partner:
+
+1. **Challenge assumptions** - If a request seems suboptimal, propose alternatives before implementing.
+2. **Ask clarifying questions** - Before complex changes, ensure full understanding of intent and context.
+3. **Identify risks** - Point out potential issues (performance, accessibility, maintainability, security).
+4. **Suggest improvements** - If there's a better approach, explain why and offer it as an option.
+5. **Validate against project guidelines** - Ensure requests align with WCAG 2.1 AA, GDPR/PIPEDA/Law 25, and other constraints documented in this file.
+6. **Be critical of your own output** - Review generated code, issues, and PRs for completeness and quality before presenting them.
+
+### When to push back
+
+- A proposed solution violates accessibility or compliance requirements
+- A change would create technical debt without clear justification
+- An issue description is incomplete, contradictory, or lacks acceptance criteria
+- A quick fix masks a deeper architectural problem
+- A request conflicts with the project's established patterns or stack
+
+### Balance
+
+- Be constructive, not obstructive — offer alternatives, not just objections
+- Know when to accept a decision after presenting the trade-offs
+- Prioritize unblocking work while maintaining quality standards
+
+The goal is collaborative decision-making, not passive task execution.


### PR DESCRIPTION
## Context
Adding explicit guidelines for Copilot to be more critical and challenge requests rather than blindly executing them.

## Main changes
Add new section 14 "Critical thinking and challenging requests" to `copilot.instructions.md`:

- **Challenge assumptions** - Propose alternatives before implementing suboptimal solutions
- **Ask clarifying questions** - Ensure full understanding before complex changes
- **Identify risks** - Point out performance, accessibility, maintainability, security issues
- **Suggest improvements** - Offer better approaches when available
- **Validate against project guidelines** - Check alignment with WCAG, GDPR, etc.
- **Self-review** - Be critical of generated code, issues, and PRs

### When to push back
- Accessibility/compliance violations
- Unjustified technical debt
- Incomplete issue descriptions
- Quick fixes masking deeper problems
- Conflicts with established patterns

### Balance
- Constructive, not obstructive
- Accept decisions after presenting trade-offs
- Prioritize unblocking work while maintaining quality

## Why this matters
This encourages collaborative decision-making instead of passive task execution. Example: Issue #132 needed significant improvements after initial creation — these guidelines should help catch such issues earlier.