### PR TITLE
fix: use JS expression for newline in Hero title

### DIFF
--- a/app/components/layout/hero/hero.stories.tsx
+++ b/app/components/layout/hero/hero.stories.tsx
@@ -47,7 +47,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     variant: "default",
-    title: "Épanouir\nsa féminité",
+    title: `Épanouir
+sa féminité`,
     subtitle: "Avec Pauline Roussel",
     multiline: true,
   },

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -63,7 +63,7 @@ export default function Home() {
         {/* Hero Section - "Épanouir sa féminité" */}
         <Hero
           variant="default"
-          title="Épanouir\nsa féminité"
+          title={"Épanouir\nsa féminité"}
           subtitle="Avec Pauline Roussel"
           multiline={true}
           containerSize="xl"


### PR DESCRIPTION
## Context

Le titre du Hero affichait littéralement `\n` au lieu de créer un saut de ligne visuel.

## Problème

En JSX, quand on utilise des guillemets doubles pour un attribut (`title="Épanouir\nsa féminité"`), la séquence `\n` est traitée comme deux caractères littéraux (backslash + n) et non comme un caractère de saut de ligne.

## Solution

- Utiliser une expression JavaScript avec accolades : `title={"Épanouir\nsa féminité"}`
- Utiliser un template literal pour les args Storybook

## Changements

| Fichier | Modification |
|---------|--------------|
| `app/routes/home.tsx` | `title={"Épanouir\nsa féminité"}` au lieu de `title="..."` |
| `app/components/layout/hero/hero.stories.tsx` | Template literal pour le titre multiline |

## Tests

- ✅ 39/39 tests passent
- ✅ Rendu visuel vérifié dans Storybook