### PR TITLE
[ #161 ] Increase method title font size in About section

### DIFF
--- a/app/components/layout/about/about.tsx
+++ b/app/components/layout/about/about.tsx
@@ -215,7 +215,7 @@ export function About({
                     <h3
                       id={`method-${item.id}-title`}
                       className={cn(
-                        "font-medium text-2xl sm:text-4xl text-secondary leading-tight",
+                        "font-medium text-3xl sm:text-5xl lg:text-7xl text-secondary leading-tight",
                         useAccentFont ? "font-accent" : "font-heading"
                       )}
                     >


### PR DESCRIPTION
## Context

Minor design adjustment to improve visual hierarchy in the About section.

Related to #161

## Main Changes

- Increased method title font size from `text-2xl sm:text-4xl` to `text-3xl sm:text-5xl lg:text-7xl`
- Better visual hierarchy and readability on all screen sizes

## Accessibility Impact

- Improved readability with larger titles
- No regressions in WCAG 2.1 AA compliance

## Performance Impact

- No changes