### PR TITLE
[ #301 ] Document Resend environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# =============================================================================
+# Shooting Star – Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in the values.
+#   cp .env.example .env
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Resend – Transactional Email (https://resend.com)
+# -----------------------------------------------------------------------------
+# Emails are sent from the dedicated subdomain mail.paulineroussel.ca
+# to protect the root domain's DNS reputation.
+
+# API key from the Resend dashboard
+RESEND_API_KEY=
+
+# Sender address on the transactional subdomain
+RESEND_FROM_EMAIL=hello@mail.paulineroussel.ca
+
+# Display name shown in the "From" field
+RESEND_FROM_NAME=Pauline Roussel
+
+# Reply-to address – replies go to Pauline's personal inbox
+CONTACT_REPLY_TO=pauline@paulineroussel.ca

--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ shooting-star/
 └── build/                 # Production build output (generated)
 ```
 
+### Environment Variables
+
+The application uses environment variables for email delivery via [Resend](https://resend.com). Copy the example file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `RESEND_API_KEY` | API key from the Resend dashboard | `re_xxxxxxxxxx` |
+| `RESEND_FROM_EMAIL` | Sender address on the transactional subdomain | `hello@mail.paulineroussel.ca` |
+| `RESEND_FROM_NAME` | Display name for outgoing emails | `Pauline Roussel` |
+| `CONTACT_REPLY_TO` | Reply-to address (Pauline's personal inbox) | `pauline@paulineroussel.ca` |
+
+> **Why `mail.paulineroussel.ca`?** Transactional emails are sent from a dedicated subdomain to protect the reputation of the root domain (`paulineroussel.ca`). If deliverability issues arise, only the subdomain is affected.
+
 ---
 
 ## 🎨 Design System Usage


### PR DESCRIPTION
## Context

Related to #301

This PR addresses the documentation portion of the DNS configuration for `mail.paulineroussel.ca` (Resend transactional email). The manual DNS/dashboard steps are handled outside of this repository.

## Main changes

- **README.md** — Added an "Environment Variables" section documenting the four required variables (`RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `CONTACT_REPLY_TO`) with a table and an explanation of why a dedicated subdomain is used.
- **.env.example** — Created a ready-to-copy template with default values and comments explaining each variable.

## Accessibility impact

No UI changes — documentation only.

## Performance impact

None.

## Compliance impact

No personal data is stored in the `.env.example` file. The `CONTACT_REPLY_TO` value is a business contact address already publicly available. Email handling via Resend will comply with PIPEDA / Law 25 requirements as implemented in #298.