### PR TITLE
[ #0 ] Finalize Story 1.1 status artifacts

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-create-content-abstraction-layer.md
+++ b/_bmad-output/implementation-artifacts/1-1-create-content-abstraction-layer.md
@@ -1,6 +1,6 @@
 # Story 1.1: Create content abstraction layer
 
-Status: review
+Status: done
 
 ## Story
 
@@ -122,7 +122,7 @@ so that routes are decoupled from the data layer and a future CMS migration requ
 ## Story completion status
 
 - Story context generated with implementation guardrails, explicit file targets, and anti-regression boundaries.
-- Sprint tracking target status for this story: `ready-for-dev`.
+- Sprint tracking target status for this story: `done`.
 - Completion note: Ultimate context engine analysis completed - comprehensive developer guide created.
 
 ## Dev Agent Record
@@ -179,3 +179,4 @@ Claude Opus 4.6
 ## Change Log
 
 - 2026-02-14: Created content abstraction layer (`app/lib/content.server.ts`) with typed interfaces and accessor functions. Migrated all direct `~/data/*` imports in 5 consumer files. Validation aligned to current Chromatic-first policy and typecheck.
+- 2026-02-14: Story merged to `main`; status updated to `done` in implementation artifacts.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -41,7 +41,7 @@ story_location: /workspaces/shooting-star/_bmad-output/implementation-artifacts
 
 development_status:
   epic-1: in-progress
-  1-1-create-content-abstraction-layer: review
+  1-1-create-content-abstraction-layer: done
   1-2-normalize-file-naming-conventions: backlog
   1-3-establish-test-conventions-documentation: backlog
   epic-1-retrospective: optional


### PR DESCRIPTION
Related to #0

## Context
This PR finalizes implementation artifact tracking after Story 1.1 was merged.

## Main changes
- Set Story 1.1 status to done
- Set sprint status entry 1-1-create-content-abstraction-layer to done
- Added post-merge changelog line in the story artifact

## Accessibility impact
- No UI changes

## Performance impact
- No runtime impact

## Compliance impact
- No personal data handling changes
