### PR TITLE
[ #0 ] Rationalize Storybook scope (phase 2)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config: StorybookConfig = {
   stories: [
     "../stories/**/*.mdx",
-    "../app/components/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    // Phase 2 rationalization: keep core component stories only
+    "../app/components/layout/header/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/hero/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/call-to-action/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/services/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/about/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/feature-block/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/footer/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/contact/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/event-card/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/components/layout/event-list/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     // Phase 1 rationalization: keep only minimal route smoke stories
     "../app/routes/home.stories.tsx",
     "../app/routes/contact.stories.tsx",


### PR DESCRIPTION
Related to #0

## Context
Cette PR applique la phase 2 de rationalisation Storybook, après la phase 1 déjà fusionnée.
L’objectif est de réduire davantage la volumétrie active sans perdre la couverture visuelle essentielle.

## Main changes
- Réduction du scope Storybook dans [.storybook/main.ts](.storybook/main.ts).
- Conservation des stories layout/core les plus utiles (header, hero, CTA, services, about, feature-block, footer, contact, event-card, event-list).
- Conservation d’un smoke minimal de pages route: [app/routes/home.stories.tsx](app/routes/home.stories.tsx) et [app/routes/contact.stories.tsx](app/routes/contact.stories.tsx).
- Exclusion des stories moins prioritaires pour cette phase (ex. carousel avancé, sections secondaires, primitives UI non critiques).

## Accessibility impact
- Aucun changement runtime des composants.
- Les stories critiques d’accessibilité restent couvertes sur les blocs principaux.

## Performance impact
- Réduction du nombre de fichiers Storybook testés: de 20 à 14.
- Réduction du nombre de tests Storybook: de 156 à 108.
- Baisse du bruit CI et de la surface de maintenance.

## Compliance impact
- Aucun impact sur la collecte/traitement des données.
- Aucun changement consentement/cookies/tracking.
- Pas d’impact GDPR / PIPEDA / Loi 25.

## Validation
- `npm run test:stories` passe en local (14 fichiers, 108 tests).
