### PR TITLE
[ #0 ] Rationalize Storybook scope (phase 3 core set)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,20 +8,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config: StorybookConfig = {
   stories: [
     "../stories/**/*.mdx",
-    // Phase 2 rationalization: keep core component stories only
+    // Phase 3 rationalization: keep high-value core stories only
     "../app/components/layout/header/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../app/components/layout/hero/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../app/components/layout/call-to-action/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../app/components/layout/services/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../app/components/layout/about/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../app/components/layout/feature-block/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../app/components/layout/footer/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../app/components/layout/contact/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../app/components/layout/event-card/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../app/components/layout/event-list/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    // Phase 1 rationalization: keep only minimal route smoke stories
+    // Keep a minimal page-level smoke story
     "../app/routes/home.stories.tsx",
-    "../app/routes/contact.stories.tsx",
   ],
   addons: [
     "@chromatic-com/storybook",


### PR DESCRIPTION
Related to #0

## Context
Cette PR pousse la rationalisation Storybook à une phase 3 “core set”.
Objectif: garder uniquement les stories à plus forte valeur visuelle/maintenance.

## Main changes
- Mise à jour du scope stories dans [.storybook/main.ts](.storybook/main.ts).
- Retrait des blocs moins prioritaires de la phase 2 (hero/services/about/feature-block + route contact).
- Conservation du noyau critique:
  - Header, Call-to-action, Footer
  - Contact (section/form/info)
  - Event card / Event list
  - Smoke page: home

## Accessibility impact
- Couverture visuelle conservée sur les composants d’interaction critiques.
- Aucun changement runtime côté composants.

## Performance impact
- Storybook tests: de 14 fichiers / 108 tests à 9 fichiers / 57 tests.
- Réduction sensible du temps d’exécution et de la surface de maintenance.

## Compliance impact
- Aucun impact collecte/traitement des données.
- Aucun changement cookies/tracking/consentement.
- Pas d’impact GDPR / PIPEDA / Loi 25.

## Validation
- `npm run test:stories` passe en local (9 fichiers, 57 tests).
